### PR TITLE
Opinion: remove syserr logging from `AppearanceSupport`

### DIFF
--- a/src/org/violetlib/vaquaclient/AppearanceSupport.java
+++ b/src/org/violetlib/vaquaclient/AppearanceSupport.java
@@ -125,7 +125,6 @@ public class AppearanceSupport
                 ClassLoader classLoader = laf.getClass().getClassLoader();
                 try {
                     vAppearancesClass = Class.forName("org.violetlib.vappearances.VAppearances", true, classLoader);
-                    System.err.println("Loaded VAppearances using VAqua class loader");
                     return vAppearancesClass;
                 } catch (Exception ex) {
                     System.err.println("Did not find VAppearances using VAqua class loader");
@@ -137,7 +136,6 @@ public class AppearanceSupport
             // possible.
             try {
                 vAppearancesClass = Class.forName("org.violetlib.vappearances.VAppearances");
-                System.err.println("Loaded VAppearances because look and feel is " + laf.getName());
                 return vAppearancesClass;
             } catch (Exception ex) {
                 System.err.println("Did not find VAppearances using application class loader");


### PR DESCRIPTION
I think these are maybe no longer necessary? They could change to `java.util.logging` or something like that? Or maybe it's okay just to remove them?